### PR TITLE
added webhook class to pass frames to client

### DIFF
--- a/ray_actors/grpc_client_start.py
+++ b/ray_actors/grpc_client_start.py
@@ -2,7 +2,7 @@ import grpc
 from generated import server_commands_pb2_grpc as pb2_grpc
 from generated import server_commands_pb2 as pb2
 
-_WEBHOOK = "http://localhost:8000/callback"
+_WEBHOOK = "http://192.168.1.188:3000/webhooks/camera"
 _INPUT = "rtsp://127.23.23.15:8554/mystream_4"
 _NAME = "channel_1"
 

--- a/ray_actors/webhook.py
+++ b/ray_actors/webhook.py
@@ -1,0 +1,55 @@
+import base64
+from uu import Error
+import requests
+from typing import Dict
+import cv2
+from dataclasses import dataclass
+
+@dataclass
+class WebhookFrame():
+    cameraId:str
+    lot:str
+    expiry:str
+    mime:str
+    imageBase64:str
+
+class Webhook:
+    def to_base64(self, frame, include_data_url=True):
+        _, buffer = cv2.imencode('.jpg', frame)
+        frame_based64 = base64.b64encode(buffer).decode('utf-8')
+        if include_data_url:
+            return f"data:image/jpeg;base64,{frame_based64}"
+        
+        return frame_based64
+
+    def resize_frame(self, frame):
+        height, width, _ = frame.shape
+        half_h = height // 2
+        half_w = width // 2
+        return cv2.resize(frame, (half_w, half_h), cv2.INTER_LINEAR)
+    
+    def send_webhook(self, webhook_url: str, webhook_frame: WebhookFrame) -> bool:
+        
+        body = {
+            "cameraId":webhook_frame.cameraId,
+            "lot":webhook_frame.lot,
+            "expiry":webhook_frame.expiry,
+            "mime":webhook_frame.mime,
+            "imageBase64":webhook_frame.imageBase64
+        }
+
+        headers = {
+            "Content-Type":"application/json"
+        }
+        print(f"Webhook:{webhook_url=}")
+        response = None
+
+        try:
+            response = requests.post(webhook_url, json=body, headers=headers, timeout=10)
+            print(response.status_code)
+            print(response.text) 
+        except requests.exceptions.RequestException as e:
+            print(e)
+
+        success:bool = True if response.status_code == 200 else False
+        return success


### PR DESCRIPTION
This pull request introduces a webhook integration for sending processed video frames and detection metadata from the video processor to an external endpoint. The main changes include adding a new `Webhook` utility, updating the video processor to use this webhook, and changing the webhook callback URL. These updates enable real-time notification and frame delivery after detection and OCR processing.

**Webhook Integration:**

* Added new `webhook.py` module containing the `Webhook` class for encoding frames to base64, resizing frames, and sending webhook requests, as well as the `WebhookFrame` dataclass to structure webhook payloads.
* Updated `video_processor.py` to import and instantiate the `Webhook` class, and to send a webhook with detection results and the processed frame after each run. [[1]](diffhunk://#diff-9a912fc2ccbd816538d978254f379dfd83abe614770746316791478194e0693fR10) [[2]](diffhunk://#diff-9a912fc2ccbd816538d978254f379dfd83abe614770746316791478194e0693fR42) [[3]](diffhunk://#diff-9a912fc2ccbd816538d978254f379dfd83abe614770746316791478194e0693fR200-R211)

**Configuration Update:**

* Changed the webhook callback URL in `grpc_client_start.py` to point to the new external endpoint.