### PR TITLE
Ocr paddle

### DIFF
--- a/ray_actors/grpc_client_start.py
+++ b/ray_actors/grpc_client_start.py
@@ -1,4 +1,5 @@
 import grpc
+import sys
 from generated import server_commands_pb2_grpc as pb2_grpc
 from generated import server_commands_pb2 as pb2
 
@@ -8,7 +9,7 @@ models = {
 }
 
 _WEBHOOK = "http://192.168.1.188:3000/webhooks/camera"
-_INPUT = "rtsp://127.23.23.15:8554/mystream_4"
+_INPUT = "rtsp://127.23.23.15:8554/mystream_"
 _NAME = "channel_1"
 _MODEL_NAME = models.get("model_oaix_box")
 
@@ -19,26 +20,39 @@ print(f"{_NAME=}")
 print(f"{_MODEL_NAME=}")
 
 
-def main(host: str = "localhost", port: int = 50051) -> None:
+def main(stream_val:str,  rotate_90_clock_wise:bool = False, host: str = "localhost", port: int = 50051) -> None:
     target = f"{host}:{port}"
     with grpc.insecure_channel(target=target) as channel:
         stub = pb2_grpc.ServerCommandsStub(channel=channel)
+        # print(pb2.Rotation.ROTATE_0, pb2.Rotation.ROTATE_90)
         channel_1 = pb2.ExecuteCommand(
             command=pb2.Command.START,
             name=_NAME,
             call_back_url=_WEBHOOK,
-            input_url=_INPUT,
-            frame_orientation=pb2.FrameOrientation.PORTRAIT,
-            rotation=pb2.Rotation.ROTATE_90,
+            input_url=_INPUT+stream_val,
+            frame_orientation=pb2.FrameOrientation.LANDSCAPE,
+            rotation=pb2.Rotation.ROTATE_90 if rotate_90_clock_wise else pb2.Rotation.ROTATE_0,
             processor_type=pb2.ProcessorType.GPU,
             model_name=_MODEL_NAME
         )
 
         req = pb2.ExecuteCommandRequest(execute_commands=[channel_1])
-
+        print(f"{channel_1=}")
         resp = stub.ExecuteCommand(req)
         print(resp)
 
 
 if __name__ == "__main__":
-    main()
+
+    print(sys.argv)
+    stream_val = 4
+    rotate_90_clock_wise = False
+
+    if len(sys.argv) > 1:
+        stream_val = sys.argv[1]
+        rotate_90_clock_wise = sys.argv[2].lower() in ('true', '1', 'yes')
+
+    print(f"{stream_val=}")
+    print(f"{rotate_90_clock_wise=}")
+
+    main(stream_val=stream_val, rotate_90_clock_wise=rotate_90_clock_wise)

--- a/ray_actors/start_mp_client_1.sh
+++ b/ray_actors/start_mp_client_1.sh
@@ -1,2 +1,2 @@
 echo "Starting client"
-python3 -m grpc_client_start
+python3 -m grpc_client_start 4 False

--- a/ray_actors/start_mp_client_2.sh
+++ b/ray_actors/start_mp_client_2.sh
@@ -1,2 +1,2 @@
 echo "Starting client"
-python3 -m grpc_client_start
+python3 -m grpc_client_start 5 False

--- a/ray_actors/video_processor.py
+++ b/ray_actors/video_processor.py
@@ -196,44 +196,41 @@ class Detection():
         normal_path = os.path.join(save_dir, f"{channel_name}_normal_{timestamp}.jpg")
         cv2.imwrite(normal_path, normal_frame)
 
-        # Build JSON-safe OCR payload (avoid numpy types)
-        safe_lines = []
-        for line in ocr_results.get('lines', []):
-            bbox = line.get('bbox', [])
-            # bbox may be list of lists or numpy arrays; coerce to ints
-            try:
-                bbox_py = [[int(pt[0]), int(pt[1])] for pt in bbox]
-            except Exception:
-                bbox_py = []
-            safe_lines.append({
-                "text": str(line.get('text', '')),
-                "confidence": float(line.get('confidence', 0.0)),
-                "bbox": bbox_py
-            })
+        # # Build JSON-safe OCR payload (avoid numpy types)
+        # safe_lines = []
+        # for line in ocr_results.get('lines', []):
+        #     bbox = line.get('bbox', [])
+        #     # bbox may be list of lists or numpy arrays; coerce to ints
+        #     try:
+        #         bbox_py = [[int(pt[0]), int(pt[1])] for pt in bbox]
+        #     except Exception:
+        #         bbox_py = []
+        #     safe_lines.append({
+        #         "text": str(line.get('text', '')),
+        #         "confidence": float(line.get('confidence', 0.0)),
+        #         "bbox": bbox_py
+        #     })
 
-        json_payload = {
-            "timestamp": int(timestamp),
-            "channel": str(channel_name),
-            "yolo_detections": int(len(dets)),
-            "ocr_results": {
-                "text_count": int(ocr_results.get('text_count', 0) or 0),
-                "lot": str(ocr_results.get('lot', '')),
-                "expiry": str(ocr_results.get('expiry', '')),
-                "full_text": str(ocr_results.get('text', '')),
-                "lines": safe_lines
-            }
-        }
-        with open(os.path.join(save_dir, f"{channel_name}_normal_{timestamp}.json"), 'w') as f:
-            json.dump(json_payload, f, indent=2)
+        # json_payload = {
+        #     "timestamp": int(timestamp),
+        #     "channel": str(channel_name),
+        #     "yolo_detections": int(len(dets)),
+        #     "ocr_results": {
+        #         "text_count": int(ocr_results.get('text_count', 0) or 0),
+        #         "lot": str(ocr_results.get('lot', '')),
+        #         "expiry": str(ocr_results.get('expiry', '')),
+        #         "full_text": str(ocr_results.get('text', '')),
+        #         "lines": safe_lines
+        #     }
+        # }
+        # with open(os.path.join(save_dir, f"{channel_name}_normal_{timestamp}.json"), 'w') as f:
+        #     json.dump(json_payload, f, indent=2)
 
-        # Rotated OCR frame only if any text was found
-        if ocr_results.get('text_count', 0) > 0:
-            rotated = cv2.rotate(frame, cv2.ROTATE_90_CLOCKWISE)
-            rotated = ocr.draw_ocr_results(rotated, ocr_results)
-            rotated_path = os.path.join(save_dir, f"{channel_name}_ocr_{timestamp}.jpg")
-            cv2.imwrite(rotated_path, rotated)
-            with open(os.path.join(save_dir, f"{channel_name}_ocr_{timestamp}.json"), 'w') as f:
-                json.dump({**json_payload, "frame_type": "ocr_rotated"}, f, indent=2)
+        # rotated = ocr.draw_ocr_results(rotated, ocr_results)
+        # ocr_frame_path = os.path.join(save_dir, f"{channel_name}_ocr_{timestamp}.jpg")
+        # cv2.imwrite(ocr_frame_path, rotated)
+        # with open(os.path.join(save_dir, f"{channel_name}_ocr_{timestamp}.json"), 'w') as f:
+        #     json.dump({**json_payload, "frame_type": "ocr_frame"}, f, indent=2)
 
 
     def start_worker(self):

--- a/ray_actors/video_processor.py
+++ b/ray_actors/video_processor.py
@@ -185,52 +185,16 @@ class Detection():
         os.makedirs(save_dir, exist_ok=True)
 
         # Normal annotated frame
-        normal_frame = frame.copy()
-        for bbox, cls_id, conf in dets:
-            x1, y1, x2, y2 = bbox
-            cv2.rectangle(normal_frame, (x1, y1), (x2, y2), (0, 255, 0), 2)
-            label = model.names[cls_id] if hasattr(model, 'names') else str(cls_id)
-            cv2.putText(normal_frame, f"{label} {conf:.2f}", (x1, y1 - 10),
-                        cv2.FONT_HERSHEY_PLAIN, 0.9, (0, 255, 0), 2)
-        normal_frame = ocr.draw_ocr_results(normal_frame, ocr_results)
-        normal_path = os.path.join(save_dir, f"{channel_name}_normal_{timestamp}.jpg")
-        cv2.imwrite(normal_path, normal_frame)
-
-        # # Build JSON-safe OCR payload (avoid numpy types)
-        # safe_lines = []
-        # for line in ocr_results.get('lines', []):
-        #     bbox = line.get('bbox', [])
-        #     # bbox may be list of lists or numpy arrays; coerce to ints
-        #     try:
-        #         bbox_py = [[int(pt[0]), int(pt[1])] for pt in bbox]
-        #     except Exception:
-        #         bbox_py = []
-        #     safe_lines.append({
-        #         "text": str(line.get('text', '')),
-        #         "confidence": float(line.get('confidence', 0.0)),
-        #         "bbox": bbox_py
-        #     })
-
-        # json_payload = {
-        #     "timestamp": int(timestamp),
-        #     "channel": str(channel_name),
-        #     "yolo_detections": int(len(dets)),
-        #     "ocr_results": {
-        #         "text_count": int(ocr_results.get('text_count', 0) or 0),
-        #         "lot": str(ocr_results.get('lot', '')),
-        #         "expiry": str(ocr_results.get('expiry', '')),
-        #         "full_text": str(ocr_results.get('text', '')),
-        #         "lines": safe_lines
-        #     }
-        # }
-        # with open(os.path.join(save_dir, f"{channel_name}_normal_{timestamp}.json"), 'w') as f:
-        #     json.dump(json_payload, f, indent=2)
-
-        # rotated = ocr.draw_ocr_results(rotated, ocr_results)
-        # ocr_frame_path = os.path.join(save_dir, f"{channel_name}_ocr_{timestamp}.jpg")
-        # cv2.imwrite(ocr_frame_path, rotated)
-        # with open(os.path.join(save_dir, f"{channel_name}_ocr_{timestamp}.json"), 'w') as f:
-        #     json.dump({**json_payload, "frame_type": "ocr_frame"}, f, indent=2)
+        # normal_frame = frame.copy()
+        # for bbox, cls_id, conf in dets:
+        #     x1, y1, x2, y2 = bbox
+        #     cv2.rectangle(normal_frame, (x1, y1), (x2, y2), (0, 255, 0), 2)
+        #     label = model.names[cls_id] if hasattr(model, 'names') else str(cls_id)
+        #     cv2.putText(normal_frame, f"{label} {conf:.2f}", (x1, y1 - 10), cv2.FONT_HERSHEY_PLAIN, 0.9, (0, 255, 0), 2)
+        
+        ocr_frame = ocr.draw_ocr_results(frame, ocr_results)
+        ocr_path = os.path.join(save_dir, f"{channel_name}_ocr_{timestamp}.jpg")
+        cv2.imwrite(ocr_path, ocr_frame)
 
 
     def start_worker(self):
@@ -327,7 +291,7 @@ class Detection():
 
                 # Decide whether to OCR based on focus and duplicates on ROI
                 if do_ocr and self._stable_target:
-                    roi = self._crop_expand(frame, self._stable_target['bbox'], margin_ratio=0.25)
+                    roi = self._crop_expand(frame, self._stable_target['bbox'], margin_ratio=0.3)
                     # Focus check
                     focus_val = self._variance_of_laplacian(roi)
                     # Duplicate ROI check using perceptual hash
@@ -343,6 +307,7 @@ class Detection():
                         ocr_triggered = True
                         self._last_roi_hash = roi_hash
                         # Start cooldown regardless of OCR outcome to avoid hammering
+                        self.save_outputs(self.name, channel_run, roi, dets, ocr_results, model, ocr)
                         self._cooldown_remaining = self.ocr_cooldown_frames
                     else:
                         ocr_time = 0.0
@@ -352,7 +317,7 @@ class Detection():
                     ocr_time = 0.0
 
                 # Save annotated outputs and select best frame for webhook
-                self.save_outputs(self.name, channel_run, frame, dets, ocr_results, model, ocr)
+                # self.save_outputs(self.name, channel_run, frame, dets, ocr_results, model, ocr)
 
                 # Only send when OCR actually ran and produced some text, and text changed
                 sent = False

--- a/rtsp_streamer/start_stream_4.sh
+++ b/rtsp_streamer/start_stream_4.sh
@@ -3,9 +3,14 @@ echo "Running start_stream_1.sh"
 IP=$(ip route get 8.8.8.8 | awk '{print $7}')
 echo "IP: $IP"
 
-ffmpeg -re -stream_loop -1 -i videos/emi_test.mp4 \
-  -c:v libx264 -preset veryfast -tune zerolatency -pix_fmt yuv420p \
+ffmpeg -re -stream_loop -1 -i videos/medicines.mp4 \
+  -vf "scale=1920:1080" \
+  -c:v libx264 -preset medium -profile:v main -level 4.0 \
+  -pix_fmt yuv420p -r 30 -g 60 -keyint_min 60 -sc_threshold 0 \
+  -b:v 2000k -maxrate 2500k -bufsize 4000k \
+  -x264-params "nal-hrd=cbr:force-cfr=1" \
   -c:a aac -ar 44100 -b:a 128k -ac 2 \
-  -f rtsp -rtsp_transport tcp rtsp://$IP:8554/mystream_4
+  -f rtsp -rtsp_transport tcp \
+  rtsp://$IP:8554/mystream_4
 
 echo "Stream 4 started"

--- a/rtsp_streamer/start_stream_5.sh
+++ b/rtsp_streamer/start_stream_5.sh
@@ -1,0 +1,11 @@
+echo "Running start_stream_1.sh"
+
+IP=$(ip route get 8.8.8.8 | awk '{print $7}')
+echo "IP: $IP"
+
+ffmpeg -re -stream_loop -1 -i videos/emi_test.mp4 \
+  -c:v libx264 -preset veryfast -tune zerolatency -pix_fmt yuv420p \
+  -c:a aac -ar 44100 -b:a 128k -ac 2 \
+  -f rtsp -rtsp_transport tcp rtsp://$IP:8554/mystream_5
+
+echo "Stream 5 started"


### PR DESCRIPTION
This pull request introduces several changes to improve the flexibility and behavior of the video processing pipeline and streaming scripts. The main updates include making the gRPC client configurable via command-line arguments, modifying how frames are processed and saved (especially regarding OCR), and updating the streaming scripts for different input videos and stream parameters.

### gRPC Client Configuration and Invocation

* The `grpc_client_start.py` script now accepts command-line arguments for stream selection and frame rotation, allowing dynamic configuration of the input stream and orientation without modifying the code. The input stream URL is constructed using the provided stream value, and the rotation is set based on the argument. (`ray_actors/grpc_client_start.py`, `ray_actors/start_mp_client_1.sh`, `ray_actors/start_mp_client_2.sh`) [[1]](diffhunk://#diff-b017ba8f0fd4125dbc1ce3b0c5913dd1cce6255e4f054735c0fcacd6ca266a22R2) [[2]](diffhunk://#diff-b017ba8f0fd4125dbc1ce3b0c5913dd1cce6255e4f054735c0fcacd6ca266a22L11-R12) [[3]](diffhunk://#diff-b017ba8f0fd4125dbc1ce3b0c5913dd1cce6255e4f054735c0fcacd6ca266a22L22-R58) [[4]](diffhunk://#diff-3ba7152cba8e0ddb66fc074b3cc8e2faa3ceeb97db38a462b7afd0a126c35e2dL2-R2) [[5]](diffhunk://#diff-f09b08a6ee9c83b39c9194b9d12b6b21bbe9fb9f42a87951153e8bd6aa05bbc5L2-R2)

### Video Processing and OCR Output Changes

* The `video_processor.py` logic for saving outputs has been simplified: normal annotated frames and their corresponding JSON payloads are no longer saved, and only OCR-annotated frames are saved regardless of detected text. Additionally, the margin ratio for cropping the ROI before OCR is increased for potentially better results. (`ray_actors/video_processor.py`) [[1]](diffhunk://#diff-9a912fc2ccbd816538d978254f379dfd83abe614770746316791478194e0693fL188-R197) [[2]](diffhunk://#diff-9a912fc2ccbd816538d978254f379dfd83abe614770746316791478194e0693fL333-R294)
* The OCR output saving is now triggered only for the cropped ROI frame when OCR is performed, and not for every frame, reducing redundant saves. (`ray_actors/video_processor.py`) [[1]](diffhunk://#diff-9a912fc2ccbd816538d978254f379dfd83abe614770746316791478194e0693fR310) [[2]](diffhunk://#diff-9a912fc2ccbd816538d978254f379dfd83abe614770746316791478194e0693fL358-R320)

### RTSP Streaming Script Updates

* The `start_stream_4.sh` script has been updated to use a new video source (`medicines.mp4`), to apply scaling to 1920x1080, and to set more appropriate encoding parameters for improved stream quality and compatibility. (`rtsp_streamer/start_stream_4.sh`)
* A new `start_stream_5.sh` script is added to support an additional RTSP stream using `emi_test.mp4` and similar encoding settings as previous streams. (`rtsp_streamer/start_stream_5.sh`)